### PR TITLE
Revert build-namelist change and remove input_pathname argument

### DIFF
--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3080,112 +3080,55 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    }
 
    add_default($nl, 'clubb_do_icesuper');
-   add_default($nl, 'clubb_do_energyfix');
-   add_default($nl, 'clubb_cloudtop_cooling');
+
+   add_default($nl, 'clubb_expldiff');
    add_default($nl, 'clubb_rainevap_turb');
+   add_default($nl, 'clubb_cloudtop_cooling');
+   add_default($nl, 'clubb_timestep');
    add_default($nl, 'clubb_rnevap_effic');
 
-   add_default($nl, 'clubb_timestep');
-   add_default($nl, 'clubb_l_diag_Lscale_from_tau');
-
-   my $clubb_Lscale_from_tau = $nl->get_value('clubb_l_diag_Lscale_from_tau');
-
-   if($clubb_Lscale_from_tau =~ "true") {
-       add_default($nl, 'clubb_c1', 'val'=>1.0);
-       add_default($nl, 'clubb_c1b', 'val'=>1.0);
-       add_default($nl, 'clubb_C2rt', 'val'=>1.0);
-       add_default($nl, 'clubb_C2thl', 'val'=>1.0);
-       add_default($nl, 'clubb_C2rtthl', 'val'=>1.0);
-       add_default($nl, 'clubb_C4', 'val'=>5.2);
-       add_default($nl, 'clubb_C_uu_shr', 'val'=>0.1076484659222455);
-       add_default($nl, 'clubb_C_uu_buoy', 'val'=>0.3);
-       add_default($nl, 'clubb_c6rt', 'val'=>2.0);
-       add_default($nl, 'clubb_c6rtb', 'val'=>2.0);
-       add_default($nl, 'clubb_c6rtc', 'val'=>1.0);
-       add_default($nl, 'clubb_c6thl', 'val'=>2.0);
-       add_default($nl, 'clubb_c6thlb', 'val'=>2.0);
-       add_default($nl, 'clubb_c6thlc', 'val'=>1.0);
-       add_default($nl, 'clubb_C8', 'val'=>3.440377776099962);
-       add_default($nl, 'clubb_C8b', 'val'=>0.0);
-       add_default($nl, 'clubb_c11', 'val'=>0.31057411754034614);
-       add_default($nl, 'clubb_c11b', 'val'=>0.3250718127387944);
-       add_default($nl, 'clubb_c14', 'val'=>1.0);
-       add_default($nl, 'clubb_C_invrs_tau_bkgnd', 'val'=>3.727123755772682);
-       add_default($nl, 'clubb_C_invrs_tau_sfc', 'val'=>0.12743072568015346);
-       add_default($nl, 'clubb_C_invrs_tau_shear', 'val'=>0.12502726304767026);
-       add_default($nl, 'clubb_C_invrs_tau_N2', 'val'=>0.08122667220596895);
-       add_default($nl, 'clubb_C_invrs_tau_N2_wp2', 'val'=>0.1);
-       add_default($nl, 'clubb_C_invrs_tau_N2_xp2', 'val'=>0.05);
-       add_default($nl, 'clubb_C_invrs_tau_N2_wpxp', 'val'=>0.0);
-       add_default($nl, 'clubb_C_invrs_tau_N2_clear_wp3', 'val'=>1.0);
-       add_default($nl, 'clubb_gamma_coef', 'val'=>0.5492223674353673);
-       add_default($nl, 'clubb_gamma_coefb', 'val'=>0.2531868210746816);
-       add_default($nl, 'clubb_beta', 'val'=>2.27756371212011);
-   } else {
-       add_default($nl, 'clubb_c1');
-       add_default($nl, 'clubb_c1b');
-       add_default($nl, 'clubb_C2rt');
-       add_default($nl, 'clubb_C2thl');
-       add_default($nl, 'clubb_C2rtthl');
-       add_default($nl, 'clubb_C4');
-       add_default($nl, 'clubb_C_uu_shr');
-       add_default($nl, 'clubb_C_uu_buoy');
-       add_default($nl, 'clubb_c6rt');
-       add_default($nl, 'clubb_c6rtb');
-       add_default($nl, 'clubb_c6rtc');
-       add_default($nl, 'clubb_c6thl');
-       add_default($nl, 'clubb_c6thlb');
-       add_default($nl, 'clubb_c6thlc');
-       add_default($nl, 'clubb_C8');
-       add_default($nl, 'clubb_C8b');
-       add_default($nl, 'clubb_c11');
-       add_default($nl, 'clubb_c11b');
-       add_default($nl, 'clubb_c14');
-       add_default($nl, 'clubb_C_invrs_tau_bkgnd');
-       add_default($nl, 'clubb_C_invrs_tau_sfc');
-       add_default($nl, 'clubb_C_invrs_tau_shear');
-       add_default($nl, 'clubb_C_invrs_tau_N2');
-       add_default($nl, 'clubb_C_invrs_tau_N2_wp2');
-       add_default($nl, 'clubb_C_invrs_tau_N2_xp2');
-       add_default($nl, 'clubb_C_invrs_tau_N2_wpxp');
-       add_default($nl, 'clubb_C_invrs_tau_N2_clear_wp3');
-       add_default($nl, 'clubb_gamma_coef');
-       add_default($nl, 'clubb_gamma_coefb');
-       add_default($nl, 'clubb_beta');
-   }
-
+   add_default($nl, 'clubb_beta');
+   add_default($nl, 'clubb_c1');
+   add_default($nl, 'clubb_c1b');
+   add_default($nl, 'clubb_c11');
+   add_default($nl, 'clubb_c11b');
+   add_default($nl, 'clubb_c14');
+   add_default($nl, 'clubb_C2rt');
+   add_default($nl, 'clubb_C2thl');
+   add_default($nl, 'clubb_C2rtthl');
+   add_default($nl, 'clubb_C4');
+   add_default($nl, 'clubb_c6rt');
+   add_default($nl, 'clubb_c6rtb');
+   add_default($nl, 'clubb_c6rtc');
+   add_default($nl, 'clubb_c6thl');
+   add_default($nl, 'clubb_c6thlb');
+   add_default($nl, 'clubb_c6thlc');
    add_default($nl, 'clubb_C7');
    add_default($nl, 'clubb_C7b');
-
-   add_default($nl, 'clubb_C_wp3_pr_turb');
-   add_default($nl, 'clubb_c_K1');
-   add_default($nl, 'clubb_c_K2');
-   add_default($nl, 'clubb_nu2');
-   add_default($nl, 'clubb_c_K8');
+   add_default($nl, 'clubb_C8');
+   add_default($nl, 'clubb_C8b');
    add_default($nl, 'clubb_c_K9');
    add_default($nl, 'clubb_nu9');
    add_default($nl, 'clubb_c_K10');
    add_default($nl, 'clubb_c_K10h');
    add_default($nl, 'clubb_do_liqsupersat');
-   add_default($nl, 'clubb_wpxp_L_thresh');
-
+   add_default($nl, 'clubb_gamma_coef');
+   add_default($nl, 'clubb_gamma_coefb');
    add_default($nl, 'clubb_lambda0_stability_coef');
    add_default($nl, 'clubb_lmin_coef');
    add_default($nl, 'clubb_mult_coef');
    add_default($nl, 'clubb_Skw_denom_coef');
    add_default($nl, 'clubb_skw_max_mag');
-   add_default($nl, 'clubb_up2_sfc_coef');
+   add_default($nl, 'clubb_up2_vp2_factor');
    add_default($nl, 'clubb_C_wp2_splat');
+   add_default($nl, 'clubb_wpxp_L_thresh');
    add_default($nl, 'clubb_detliq_rad');
    add_default($nl, 'clubb_detice_rad');
    add_default($nl, 'clubb_detphase_lowtemp');
-   add_default($nl, 'clubb_ipdf_call_placement');
 
    add_default($nl, 'clubb_l_brunt_vaisala_freq_moist');
    add_default($nl, 'clubb_l_call_pdf_closure_twice');
    add_default($nl, 'clubb_l_damp_wp3_Skw_squared');
-   add_default($nl, 'clubb_l_lmm_stepping');
-   add_default($nl, 'clubb_l_e3sm_config');
    add_default($nl, 'clubb_l_lscale_plume_centered');
    add_default($nl, 'clubb_l_min_wp2_from_corr_wx');
    add_default($nl, 'clubb_l_min_xp2_from_corr_wx');
@@ -3198,18 +3141,11 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    add_default($nl, 'clubb_l_use_C7_Richardson');
    add_default($nl, 'clubb_l_use_C11_Richardson');
    add_default($nl, 'clubb_l_use_cloud_cover');
+   add_default($nl, 'clubb_l_use_ice_latent');
    add_default($nl, 'clubb_l_use_thvm_in_bv_freq');
    add_default($nl, 'clubb_l_vert_avg_closure');
+   add_default($nl, 'clubb_l_diag_Lscale_from_tau');
    add_default($nl, 'clubb_l_damp_wp2_using_em');
-   add_default($nl, 'clubb_l_godunov_upwind_wpxp_ta');
-   add_default($nl, 'clubb_l_godunov_upwind_xpyp_ta');
-   add_default($nl, 'clubb_l_use_shear_Richardson');
-   add_default($nl, 'clubb_l_use_tke_in_wp3_pr_turb_term');
-   add_default($nl, 'clubb_l_use_tke_in_wp2_wp3_K_dfsn');
-   add_default($nl, 'clubb_l_smooth_Heaviside_tau_wpxp');
-   add_default($nl, 'clubb_l_do_expldiff_rtm_thlm');
-
-   #CLUBB+MF options
    add_default($nl, 'do_clubb_mf');
    add_default($nl, 'do_clubb_mf_diag');
    add_default($nl, 'clubb_mf_L0');

--- a/bld/build-namelist
+++ b/bld/build-namelist
@@ -3080,55 +3080,112 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    }
 
    add_default($nl, 'clubb_do_icesuper');
-
-   add_default($nl, 'clubb_expldiff');
-   add_default($nl, 'clubb_rainevap_turb');
+   add_default($nl, 'clubb_do_energyfix');
    add_default($nl, 'clubb_cloudtop_cooling');
-   add_default($nl, 'clubb_timestep');
+   add_default($nl, 'clubb_rainevap_turb');
    add_default($nl, 'clubb_rnevap_effic');
 
-   add_default($nl, 'clubb_beta');
-   add_default($nl, 'clubb_c1');
-   add_default($nl, 'clubb_c1b');
-   add_default($nl, 'clubb_c11');
-   add_default($nl, 'clubb_c11b');
-   add_default($nl, 'clubb_c14');
-   add_default($nl, 'clubb_C2rt');
-   add_default($nl, 'clubb_C2thl');
-   add_default($nl, 'clubb_C2rtthl');
-   add_default($nl, 'clubb_C4');
-   add_default($nl, 'clubb_c6rt');
-   add_default($nl, 'clubb_c6rtb');
-   add_default($nl, 'clubb_c6rtc');
-   add_default($nl, 'clubb_c6thl');
-   add_default($nl, 'clubb_c6thlb');
-   add_default($nl, 'clubb_c6thlc');
+   add_default($nl, 'clubb_timestep');
+   add_default($nl, 'clubb_l_diag_Lscale_from_tau');
+
+   my $clubb_Lscale_from_tau = $nl->get_value('clubb_l_diag_Lscale_from_tau');
+
+   if($clubb_Lscale_from_tau =~ "true") {
+       add_default($nl, 'clubb_c1', 'val'=>1.0);
+       add_default($nl, 'clubb_c1b', 'val'=>1.0);
+       add_default($nl, 'clubb_C2rt', 'val'=>1.0);
+       add_default($nl, 'clubb_C2thl', 'val'=>1.0);
+       add_default($nl, 'clubb_C2rtthl', 'val'=>1.0);
+       add_default($nl, 'clubb_C4', 'val'=>5.2);
+       add_default($nl, 'clubb_C_uu_shr', 'val'=>0.1076484659222455);
+       add_default($nl, 'clubb_C_uu_buoy', 'val'=>0.3);
+       add_default($nl, 'clubb_c6rt', 'val'=>2.0);
+       add_default($nl, 'clubb_c6rtb', 'val'=>2.0);
+       add_default($nl, 'clubb_c6rtc', 'val'=>1.0);
+       add_default($nl, 'clubb_c6thl', 'val'=>2.0);
+       add_default($nl, 'clubb_c6thlb', 'val'=>2.0);
+       add_default($nl, 'clubb_c6thlc', 'val'=>1.0);
+       add_default($nl, 'clubb_C8', 'val'=>3.440377776099962);
+       add_default($nl, 'clubb_C8b', 'val'=>0.0);
+       add_default($nl, 'clubb_c11', 'val'=>0.31057411754034614);
+       add_default($nl, 'clubb_c11b', 'val'=>0.3250718127387944);
+       add_default($nl, 'clubb_c14', 'val'=>1.0);
+       add_default($nl, 'clubb_C_invrs_tau_bkgnd', 'val'=>3.727123755772682);
+       add_default($nl, 'clubb_C_invrs_tau_sfc', 'val'=>0.12743072568015346);
+       add_default($nl, 'clubb_C_invrs_tau_shear', 'val'=>0.12502726304767026);
+       add_default($nl, 'clubb_C_invrs_tau_N2', 'val'=>0.08122667220596895);
+       add_default($nl, 'clubb_C_invrs_tau_N2_wp2', 'val'=>0.1);
+       add_default($nl, 'clubb_C_invrs_tau_N2_xp2', 'val'=>0.05);
+       add_default($nl, 'clubb_C_invrs_tau_N2_wpxp', 'val'=>0.0);
+       add_default($nl, 'clubb_C_invrs_tau_N2_clear_wp3', 'val'=>1.0);
+       add_default($nl, 'clubb_gamma_coef', 'val'=>0.5492223674353673);
+       add_default($nl, 'clubb_gamma_coefb', 'val'=>0.2531868210746816);
+       add_default($nl, 'clubb_beta', 'val'=>2.27756371212011);
+   } else {
+       add_default($nl, 'clubb_c1');
+       add_default($nl, 'clubb_c1b');
+       add_default($nl, 'clubb_C2rt');
+       add_default($nl, 'clubb_C2thl');
+       add_default($nl, 'clubb_C2rtthl');
+       add_default($nl, 'clubb_C4');
+       add_default($nl, 'clubb_C_uu_shr');
+       add_default($nl, 'clubb_C_uu_buoy');
+       add_default($nl, 'clubb_c6rt');
+       add_default($nl, 'clubb_c6rtb');
+       add_default($nl, 'clubb_c6rtc');
+       add_default($nl, 'clubb_c6thl');
+       add_default($nl, 'clubb_c6thlb');
+       add_default($nl, 'clubb_c6thlc');
+       add_default($nl, 'clubb_C8');
+       add_default($nl, 'clubb_C8b');
+       add_default($nl, 'clubb_c11');
+       add_default($nl, 'clubb_c11b');
+       add_default($nl, 'clubb_c14');
+       add_default($nl, 'clubb_C_invrs_tau_bkgnd');
+       add_default($nl, 'clubb_C_invrs_tau_sfc');
+       add_default($nl, 'clubb_C_invrs_tau_shear');
+       add_default($nl, 'clubb_C_invrs_tau_N2');
+       add_default($nl, 'clubb_C_invrs_tau_N2_wp2');
+       add_default($nl, 'clubb_C_invrs_tau_N2_xp2');
+       add_default($nl, 'clubb_C_invrs_tau_N2_wpxp');
+       add_default($nl, 'clubb_C_invrs_tau_N2_clear_wp3');
+       add_default($nl, 'clubb_gamma_coef');
+       add_default($nl, 'clubb_gamma_coefb');
+       add_default($nl, 'clubb_beta');
+   }
+
    add_default($nl, 'clubb_C7');
    add_default($nl, 'clubb_C7b');
-   add_default($nl, 'clubb_C8');
-   add_default($nl, 'clubb_C8b');
+
+   add_default($nl, 'clubb_C_wp3_pr_turb');
+   add_default($nl, 'clubb_c_K1');
+   add_default($nl, 'clubb_c_K2');
+   add_default($nl, 'clubb_nu2');
+   add_default($nl, 'clubb_c_K8');
    add_default($nl, 'clubb_c_K9');
    add_default($nl, 'clubb_nu9');
    add_default($nl, 'clubb_c_K10');
    add_default($nl, 'clubb_c_K10h');
    add_default($nl, 'clubb_do_liqsupersat');
-   add_default($nl, 'clubb_gamma_coef');
-   add_default($nl, 'clubb_gamma_coefb');
+   add_default($nl, 'clubb_wpxp_L_thresh');
+
    add_default($nl, 'clubb_lambda0_stability_coef');
    add_default($nl, 'clubb_lmin_coef');
    add_default($nl, 'clubb_mult_coef');
    add_default($nl, 'clubb_Skw_denom_coef');
    add_default($nl, 'clubb_skw_max_mag');
-   add_default($nl, 'clubb_up2_vp2_factor');
+   add_default($nl, 'clubb_up2_sfc_coef');
    add_default($nl, 'clubb_C_wp2_splat');
-   add_default($nl, 'clubb_wpxp_L_thresh');
    add_default($nl, 'clubb_detliq_rad');
    add_default($nl, 'clubb_detice_rad');
    add_default($nl, 'clubb_detphase_lowtemp');
+   add_default($nl, 'clubb_ipdf_call_placement');
 
    add_default($nl, 'clubb_l_brunt_vaisala_freq_moist');
    add_default($nl, 'clubb_l_call_pdf_closure_twice');
    add_default($nl, 'clubb_l_damp_wp3_Skw_squared');
+   add_default($nl, 'clubb_l_lmm_stepping');
+   add_default($nl, 'clubb_l_e3sm_config');
    add_default($nl, 'clubb_l_lscale_plume_centered');
    add_default($nl, 'clubb_l_min_wp2_from_corr_wx');
    add_default($nl, 'clubb_l_min_xp2_from_corr_wx');
@@ -3141,11 +3198,18 @@ if ($clubb_sgs  =~ /$TRUE/io) {
    add_default($nl, 'clubb_l_use_C7_Richardson');
    add_default($nl, 'clubb_l_use_C11_Richardson');
    add_default($nl, 'clubb_l_use_cloud_cover');
-   add_default($nl, 'clubb_l_use_ice_latent');
    add_default($nl, 'clubb_l_use_thvm_in_bv_freq');
    add_default($nl, 'clubb_l_vert_avg_closure');
-   add_default($nl, 'clubb_l_diag_Lscale_from_tau');
    add_default($nl, 'clubb_l_damp_wp2_using_em');
+   add_default($nl, 'clubb_l_godunov_upwind_wpxp_ta');
+   add_default($nl, 'clubb_l_godunov_upwind_xpyp_ta');
+   add_default($nl, 'clubb_l_use_shear_Richardson');
+   add_default($nl, 'clubb_l_use_tke_in_wp3_pr_turb_term');
+   add_default($nl, 'clubb_l_use_tke_in_wp2_wp3_K_dfsn');
+   add_default($nl, 'clubb_l_smooth_Heaviside_tau_wpxp');
+   add_default($nl, 'clubb_l_do_expldiff_rtm_thlm');
+
+   #CLUBB+MF options
    add_default($nl, 'do_clubb_mf');
    add_default($nl, 'do_clubb_mf_diag');
    add_default($nl, 'clubb_mf_L0');
@@ -4404,8 +4468,9 @@ sub check_input_files {
                         print $fh "$var = $pathname\n";
                     }
                     else {
-                        if (!($pathname =~ '%.*')) {
-                            print $fh "$var = $pathname\n";
+                        if (-e $pathname) {  # use -e rather than -f since the absolute pathname
+                                             # might be a directory
+                            print "OK -- found $var = $pathname\n";
                         }
                         else {
                             print "NOT FOUND:  $var = $pathname\n";

--- a/bld/namelist_files/namelist_definition.xml
+++ b/bld/namelist_files/namelist_definition.xml
@@ -5391,7 +5391,7 @@ Default: FALSE
 </entry>
 
 
-<entry id="scm_ana_frc_file_template" type="char*128" input_pathname="abs" category="scam"
+<entry id="scm_ana_frc_file_template" type="char*128" category="scam"
        group="scam_nl" valid_values="" >
 template for analysis forcing dataset.
 Default: set by build-namelist.


### PR DESCRIPTION
Apologies for the confusion - this should fix the warning and remove the unnecessary build-namelist change